### PR TITLE
Allow Datetime Sensors and Offset for Start Time

### DIFF
--- a/parabolic_alarm.yaml
+++ b/parabolic_alarm.yaml
@@ -181,7 +181,8 @@ trigger:
   - trigger: time
     at: 
       entity_id: !input alarm_start_time
-      offset: "{{ calculated_runtime }}"
+      offset: >-
+        "{{ calculated_runtime }}"
 condition:
   - condition: state
     entity_id: !input workday_sensor

--- a/parabolic_alarm.yaml
+++ b/parabolic_alarm.yaml
@@ -172,6 +172,7 @@ blueprint:
       default: 5
   source_url: https://github.com/steku/ha_cercadian_alarm/blob/main/parabolic_alarm.yaml
 trigger_variables:
+  input_alarm_entity: !input alarm_start_time
   input_alarm_length_1: !input alarm_length_1
   input_alarm_length_2: !input alarm_length_2
   input_alarm_length_3: !input alarm_length_3
@@ -179,10 +180,8 @@ trigger_variables:
   calculated_runtime: "{{ -(input_alarm_length_1 + input_alarm_length_2 + input_alarm_length_3)*60 if input_complete_at_start_time else 0 }}"
 trigger:
   - trigger: time
-    at: 
-      entity_id: !input alarm_start_time
-      offset: >-
-        "{{ calculated_runtime }}"
+    at: >-
+      {{ { "entity_id": input_alarm_entity, "offset": calculated_runtime } }}
 condition:
   - condition: state
     entity_id: !input workday_sensor

--- a/parabolic_alarm.yaml
+++ b/parabolic_alarm.yaml
@@ -173,8 +173,9 @@ blueprint:
   source_url: https://github.com/steku/ha_cercadian_alarm/blob/main/parabolic_alarm.yaml
 trigger:
   - trigger: time
-    at: !input alarm_start_time
-    offset: "{{ -(alarm_length_1 + alarm_length_2 + alarm_length_3)*60 if complete_at_start_time else 0 }}"
+    at: 
+      entity_id: !input alarm_start_time
+      offset: "{{ -(alarm_length_1 + alarm_length_2 + alarm_length_3)*60 if complete_at_start_time else 0 }}"
 condition:
   - condition: state
     entity_id: !input workday_sensor

--- a/parabolic_alarm.yaml
+++ b/parabolic_alarm.yaml
@@ -66,7 +66,7 @@ blueprint:
       default: 10
       selector:
         number:
-          min: 1.0
+          min: 0.0
           max: 60.0
           step: 1.0
           mode: slider
@@ -171,11 +171,17 @@ blueprint:
           mode: slider
       default: 5
   source_url: https://github.com/steku/ha_cercadian_alarm/blob/main/parabolic_alarm.yaml
+trigger_variables:
+  input_alarm_length_1: !input alarm_length_1
+  input_alarm_length_2: !input alarm_length_2
+  input_alarm_length_3: !input alarm_length_3
+  input_complete_at_start_time: !input complete_at_start_time
+  calculated_runtime: "{{ -(input_alarm_length_1 + input_alarm_length_2 + input_alarm_length_3)*60 if input_complete_at_start_time else 0 }}"
 trigger:
   - trigger: time
     at: 
       entity_id: !input alarm_start_time
-      offset: "{{ -(alarm_length_1 + alarm_length_2 + alarm_length_3)*60 if complete_at_start_time else 0 }}"
+      offset: "{{ calculated_runtime }}"
 condition:
   - condition: state
     entity_id: !input workday_sensor

--- a/parabolic_alarm.yaml
+++ b/parabolic_alarm.yaml
@@ -16,12 +16,17 @@ blueprint:
             - domain: sensor
               device_class: timestamp
           multiple: false
-    complete_at_start_time:
-      name: 🏁 Finish at Start Time
+    offset_from_start_time:
+      name: 🏁 Offset From Start Time
       description:
-        Complete the transitions by the time given in the Start Time as opposed to starting at the Start Time.
+        Adjust the amount of time before or after the set Start Time value to start the transition. Useful if the start time comes from an alarm entity and you want to adjust where in the brightness cycle you are when the alarm goes off.
+      default: 0
       selector:
-        boolean:
+        number:
+          min: -60.0
+          max: 60.0
+          step: 1.0
+          mode: slider
     workday_sensor:
       name: 📆 Workday Sensor
       description:
@@ -171,17 +176,11 @@ blueprint:
           mode: slider
       default: 5
   source_url: https://github.com/steku/ha_cercadian_alarm/blob/main/parabolic_alarm.yaml
-trigger_variables:
-  input_alarm_entity: !input alarm_start_time
-  input_alarm_length_1: !input alarm_length_1
-  input_alarm_length_2: !input alarm_length_2
-  input_alarm_length_3: !input alarm_length_3
-  input_complete_at_start_time: !input complete_at_start_time
-  calculated_runtime: "{{ -(input_alarm_length_1 + input_alarm_length_2 + input_alarm_length_3)*60 if input_complete_at_start_time else 0 }}"
 trigger:
   - trigger: time
-    at: >-
-      {{ { "entity_id": input_alarm_entity, "offset": calculated_runtime } }}
+    at:
+      entity_id: !input alarm_start_time
+      offset: !input offset_from_start_time
 condition:
   - condition: state
     entity_id: !input workday_sensor

--- a/parabolic_alarm.yaml
+++ b/parabolic_alarm.yaml
@@ -6,13 +6,15 @@ blueprint:
     alarm_start_time:
       name: 🕒 Start Time
       description:
-        Datetime helper for the alarm to start. Use time only and Workday sensor
+        Datetime helper or sensor for the alarm to start. Use time only and Workday sensor
         to determine what days to run.
       selector:
         entity:
           filter:
             - domain:
                 - input_datetime
+            - domain: sensor
+              device_class: timestamp
           multiple: false
     workday_sensor:
       name: 📆 Workday Sensor

--- a/parabolic_alarm.yaml
+++ b/parabolic_alarm.yaml
@@ -16,6 +16,12 @@ blueprint:
             - domain: sensor
               device_class: timestamp
           multiple: false
+    complete_at_start_time:
+      name: 🏁 Finish at Start Time
+      description:
+        Complete the transitions by the time given in the Start Time as opposed to starting at the Start Time.
+      selector:
+        boolean:
     workday_sensor:
       name: 📆 Workday Sensor
       description:
@@ -168,6 +174,7 @@ blueprint:
 trigger:
   - trigger: time
     at: !input alarm_start_time
+    offset: "{{ -(alarm_length_1 + alarm_length_2 + alarm_length_3)*60 if complete_at_start_time else 0 }}"
 condition:
   - condition: state
     entity_id: !input workday_sensor
@@ -220,5 +227,4 @@ action:
           steps_per_minute: !input steps_per_minute
           light_timeout: !input light_timeout
           target_light: !input target_light
-mode: parallel
-max: 10
+mode: single

--- a/parabolic_alarm.yaml
+++ b/parabolic_alarm.yaml
@@ -19,14 +19,10 @@ blueprint:
     offset_from_start_time:
       name: 🏁 Offset From Start Time
       description:
-        Adjust the amount of time before or after the set Start Time value to start the transition. Useful if the start time comes from an alarm entity and you want to adjust where in the brightness cycle you are when the alarm goes off.
-      default: 0
+        Adjust the amount of time before or after the set Start Time value to start the transition. Enter seconds or HH:MM:SS format (e.g. "-00:05:00" to start 5 minutes before the Start Time. Useful if the start time comes from an alarm entity and you want to adjust where in the brightness cycle you are when the alarm goes off. See https://www.home-assistant.io/docs/automation/trigger/#sensors-of-datetime-device-class-with-offsets for caution about using positive offsets.
+      default: "-00:05:00"
       selector:
-        number:
-          min: -60.0
-          max: 60.0
-          step: 1.0
-          mode: slider
+        text:
     workday_sensor:
       name: 📆 Workday Sensor
       description:


### PR DESCRIPTION
Thank you for the blueprint. I wanted to be able to use my phone alarm to automatically start the process and have an offet so that the lights start coming on before my alarm -- I use a similar automation for opening the blackout curtains. Just wanted to share back the mods I made in case you want to incorporate them.

This PR:
- Extend start time entity filter to also allow datetime sensors
- Add text offset for the time value to be able to start sooner. This also allows you to match a specific end time without having to manually do math to figure out the duration each time you change the Start Time.
- Fix #7 and allow 0 for Transition.

