### PR TITLE
Fix missing alarms when location is unknown

### DIFF
--- a/parabolic_alarm.yaml
+++ b/parabolic_alarm.yaml
@@ -202,9 +202,11 @@ condition:
   - condition: state
     entity_id: !input workday_sensor
     state: "on"
-  - condition: state
-    entity_id: !input person_sensor
-    state: "home"
+  - condition: not
+    conditions:
+      - condition: state
+        entity_id: !input person_sensor
+        state: "not_home"
 action:
   - choose:
       - conditions: []


### PR DESCRIPTION
I think this also fixes a bug where the alarm wouldn't trigger if more than 1 person was chosen, and one person was not home.